### PR TITLE
Update to support newer influxdb versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ annotate-influxdb
 Grafana annotations provide a way to mark points on the graph with rich events. When you hover over an annotation you can get title, tags, and text information for the event.
 This utility is command line tool to send annotation into InfluxDB database.
 
-This has been updated and tested to work with influxdb v0.12. If you are using influxdb that is older than v0.9, please use version 0.0.1.
+This has been updated and tested to work with InfluxDB v0.12. If you are using InfluxDB that is older than v0.9, please use version 0.0.1.
 
 Grafana configuration
 =====================

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,8 @@ annotate-influxdb
 Grafana annotations provide a way to mark points on the graph with rich events. When you hover over an annotation you can get title, tags, and text information for the event.
 This utility is command line tool to send annotation into InfluxDB database.
 
+This has been updated and tested to work with influxdb v0.12. If you are using influxdb that is older than v0.9, please use version 0.0.1.
+
 Grafana configuration
 =====================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click==3.3
-influxdb==0.1.13
+influxdb==2.12.0

--- a/send-annotation
+++ b/send-annotation
@@ -17,7 +17,7 @@ from influxdb import client as influxdb
 @click.option('-D', '--description', 'text', help='event description')
 def cli(db_host, db_port, db_name, user, password, title, tags, text):
     if text is None:
-        text = "\n".join([line for line in sys.stdin])
+        text = "\n".join([line.rstrip('\n') for line in sys.stdin])
 
     try:
         db = influxdb.InfluxDBClient(db_host, db_port, user, password, db_name)

--- a/send-annotation
+++ b/send-annotation
@@ -23,9 +23,12 @@ def cli(db_host, db_port, db_name, user, password, title, tags, text):
         db = influxdb.InfluxDBClient(db_host, db_port, user, password, db_name)
         tags_field = str.join(';', tags)
         data = [{
-            'name': 'events',
-            'columns': ['tags', 'text', 'title'],
-            'points': [[tags_field, text, title]]
+            'measurement': 'events',
+            'fields': {
+                'tags': tags_field,
+                'title': title,
+                'text': text
+                }
         }]
         db.write_points(data)
     except Exception as e:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     zip_safe=False,
     long_description='Write annotations (http://grafana.org/docs/features/annotations/) into InfluxDB',
     install_requires=[
-        'click==3.3',
-        'influxdb==0.1.13',
+        'click==6.6',
+        'influxdb==2.12.0',
     ],
 )


### PR DESCRIPTION
This update has been tested to work with InfluxDB v0.12. If merged, the tag should be incremented so as to preserve 0.0.1 for older InfluxDB installs.

I had to reopen this after fixing the log.
